### PR TITLE
:recycle: `utils::path::create_nested_file` 直下

### DIFF
--- a/src/command/add.rs
+++ b/src/command/add.rs
@@ -80,7 +80,7 @@ fn generate_blob_object(file_name: &str) -> Result<String, io::Error> {
     // ファイルの準備
     let file_directory = format!(".git/objects/{}", &hash[0..2]);
     let file_path = format!("{}/{}", file_directory, &hash[2..]);
-    let mut file = util::path::create_nested_file(file_path);
+    let mut file = util::path::create_nested_file(file_path)?;
 
     // zlib圧縮
     let contents_will_be_compressed = format!("{header}{contents}");

--- a/src/command/branch.rs
+++ b/src/command/branch.rs
@@ -4,7 +4,7 @@ use crate::util;
 
 pub fn create(branch_name: &str) -> std::io::Result<()> {
     let head_commit_hash = util::path::get_head_commit_hash().unwrap_or_default();
-    let mut file = util::path::create_nested_file(format!(".git/refs/heads/{branch_name}"));
+    let mut file = util::path::create_nested_file(format!(".git/refs/heads/{branch_name}"))?;
     file.write_all(head_commit_hash.as_bytes())?;
     let mut file = fs::File::create(".git/HEAD")?;
     let content = format!("ref: refs/heads/{branch_name}");

--- a/src/command/init.rs
+++ b/src/command/init.rs
@@ -6,7 +6,7 @@ use std::io::{Result, Write};
 pub fn init() -> Result<()> {
     fs::create_dir(".git")?;
     fs::create_dir(".git/objects")?;
-    util::path::create_nested_file(".git/refs/heads/main".to_string());
+    util::path::create_nested_file(".git/refs/heads/main")?;
     let mut file = File::create(".git/HEAD")?;
     file.write_all(b"ref: refs/heads/main\n")?;
     Ok(())

--- a/src/util/path.rs
+++ b/src/util/path.rs
@@ -34,11 +34,11 @@ pub fn get_head_commit_hash() -> Option<String> {
     }
 }
 
-pub fn create_nested_file(file_path: String) -> fs::File {
-    let path = Path::new(file_path.as_str());
+pub fn create_nested_file(file_path: impl AsRef<Path>) -> std::io::Result<fs::File> {
+    let path = file_path.as_ref();
     if let Some(dir) = path.parent() {
-        fs::create_dir_all(dir).unwrap();
+        fs::create_dir_all(dir)?;
     }
 
-    fs::File::create(file_path).unwrap()
+    fs::File::create(file_path)
 }


### PR DESCRIPTION
パッと見てそうはならんやろとなったので